### PR TITLE
Better support for login/logout on multilingual sites

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,7 +4,9 @@ Changelog
 0.6.4 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Better support for Login/Logout on multilingual sites by not relying on
+  'Log in' and 'Log out' on these pages. Check css locators instead.
+  [saily]
 
 
 0.6.3 (2013-06-28)

--- a/src/plone/app/robotframework/keywords.robot
+++ b/src/plone/app/robotframework/keywords.robot
@@ -29,10 +29,10 @@ Log in
     Go to  ${PLONE_URL}/login_form
     Page should contain element  __ac_name
     Page should contain element  __ac_password
-    Page should contain button  Log in
+    Page should contain element  css=#login-form .formControls input[name=submit]
     Input text for sure  __ac_name  ${userid}
     Input text for sure  __ac_password  ${password}
-    Click Button  Log in
+    Click Button  css=#login-form .formControls input[name=submit]
 
 Log in as test user
 
@@ -55,7 +55,7 @@ Log in as test user with role
 
 Log out
     Go to  ${PLONE_URL}/logout
-    Page should contain  logged out
+    Page Should Contain Element  css=#login-form
 
 
 # ----------------------------------------------------------------------------


### PR DESCRIPTION
Hi, 

When testing multilingual sites we have to override many out-of-the-box keywords. For example the log out command checks:

```
Page should contain     Logged out
```

We should think about better methods to check such common pages or actions or provide some css classes/ids in source to allow to check on. For my tests i use a keyword-file for each language i want to test on, maybe we can provide a nice boilerplate in p.a.robotframework for such needs. This fix refs to #11.
