### PR TITLE
don't fail on missing portal._original_mailhost attribute but just tear ...

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,7 +4,9 @@ Changelog
 0.8.4 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- When using the MockMailHostlayer, don't fail on missing
+  portal._original_MailHost, when running the test teardown.
+  [thet]
 
 
 0.8.3 (2014-03-04)

--- a/src/plone/app/robotframework/testing.py
+++ b/src/plone/app/robotframework/testing.py
@@ -81,11 +81,13 @@ class MockMailHostLayer(Layer):
 
     def tearDown(self):
         with ploneSite() as portal:
-            portal.MailHost = portal._original_MailHost
-            sm = getSiteManager(context=portal)
-            sm.unregisterUtility(provided=IMailHost)
-            sm.registerUtility(aq_base(portal._original_MailHost),
-                               provided=IMailHost)
+            _o_mailhost = getattr(portal, '_original_MailHost', None)
+            if _o_mailhost:
+                portal.MailHost = portal._original_MailHost
+                sm = getSiteManager(context=portal)
+                sm.unregisterUtility(provided=IMailHost)
+                sm.registerUtility(aq_base(portal._original_MailHost),
+                                   provided=IMailHost)
 
 MOCK_MAILHOST_FIXTURE = MockMailHostLayer()
 


### PR DESCRIPTION
...down the whole test stack

on my test setup, i'm missing the portal._original_MailHost attribute on test-teardown. the zope instance keeps hanging, and i have to `kill` it. the fix just tears down the test suite, when the _original_MailHost attribute cannot be found.

for my test setup see:
https://github.com/bluedynamics/bda.plone.shop/blob/master/src/bda/plone/shop/tests/__init__.py
https://github.com/bluedynamics/bda.plone.shop/blob/master/src/bda/plone/shop/tests/test_robot.py
https://github.com/bluedynamics/bda.plone.shop/blob/master/src/bda/plone/shop/tests/robot/test_shop_orderprocess.robot
