### PR TITLE
Plip 10359 - Security Control Panel migration

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,7 +4,9 @@ Changelog
 0.9.9 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Read ``use_email_as_login`` setting from the registry instead of portal
+  properties (see https://github.com/plone/Products.CMFPlone/issues/216).
+  [jcerjak]
 
 
 0.9.8 (2014-11-11)

--- a/src/plone/app/robotframework/users.py
+++ b/src/plone/app/robotframework/users.py
@@ -1,7 +1,10 @@
 # -*- coding: utf-8 -*-
 from Products.CMFCore.utils import getToolByName
-from zope.component.hooks import getSite
+from Products.CMFPlone.interfaces import ISecuritySchema
 from plone.app.robotframework.remote import RemoteLibrary
+from plone.registry.interfaces import IRegistry
+from zope.component import getUtility
+from zope.component.hooks import getSite
 
 
 class Users(RemoteLibrary):
@@ -26,10 +29,13 @@ class Users(RemoteLibrary):
 
         portal = getSite()
         registration = getToolByName(portal, 'portal_registration')
-        portal_properties = getToolByName(portal, 'portal_properties')
 
-        use_email_as_username =\
-            portal_properties.site_properties.use_email_as_login
+        registry = getUtility(IRegistry)
+        settings = registry.forInterface(
+            ISecuritySchema,
+            prefix='plone',
+        )
+        use_email_as_username = settings.use_email_as_login
 
         user_id = use_email_as_username and properties['email'] or username
         password = properties.pop('password', username)


### PR DESCRIPTION
Read security settings from the registry instead of portal properties. This is part of work on the security control panel migration: https://github.com/plone/Products.CMFPlone/issues/216

This should be merged along with https://github.com/plone/Products.CMFPlone/pull/362
