### PR TITLE
add tag wip-not_in_docs to tests, so they are not executed when build…

### DIFF
--- a/docs/source/debugging.rst
+++ b/docs/source/debugging.rst
@@ -28,6 +28,11 @@ what to do next:
 
    .. code-block:: robotframework
 
+
+      *** Settings ***
+
+      Force Tags  wip-not_in_docs
+
       *** Test Cases ***
 
       Start interactive debugger with Debug-keyword from DebugLibrary

--- a/docs/source/happy.rst
+++ b/docs/source/happy.rst
@@ -134,6 +134,8 @@ For example, a ``test_hello.robot``:
 
    *** Settings ***
 
+    Force Tags  wip-not_in_docs
+
     Resource  plone/app/robotframework/selenium.robot
 
     Test Setup  Open test browser
@@ -162,6 +164,8 @@ Here is a more complicated example with some user keywords in action:
 .. code-block:: robotframework
 
    *** Settings ***
+
+    Force Tags  wip-not_in_docs
 
     Resource  plone/app/robotframework/selenium.robot
 
@@ -318,6 +322,8 @@ what to do next:
 
     *** Settings ***
 
+    Force Tags  wip-not_in_docs
+
     Resource  plone/app/robotframework/selenium.robot
 
     Library  Remote  ${PLONE_URL}/RobotRemote
@@ -353,6 +359,8 @@ figure out what to do next.
    .. code-block:: robotframework
 
       *** Settings ***
+
+      Force Tags  wip-not_in_docs
 
       ...
 

--- a/docs/source/robot.rst
+++ b/docs/source/robot.rst
@@ -64,6 +64,8 @@ tests. Other keywords must be included by importing a keyword library in
 
    *** Settings ***
 
+   Force Tags  wip-not_in_docs
+
    Library  String
    Library  Selenium2Library
 

--- a/docs/source/saucelabs.rst
+++ b/docs/source/saucelabs.rst
@@ -81,6 +81,7 @@ Integrate with Sauce Labs
 
       *** Settings ***
 
+      Force Tags  wip-not_in_docs
       ...
 
       Resource  plone/app/robotframework/saucelabs.robot

--- a/src/plone/app/robotframework/tests/docs/test_hello.robot
+++ b/src/plone/app/robotframework/tests/docs/test_hello.robot
@@ -1,5 +1,7 @@
 *** Settings ***
 
+Force Tags  wip-not_in_docs
+
 Resource  plone/app/robotframework/selenium.robot
 
 Test Setup  Open test browser

--- a/src/plone/app/robotframework/tests/docs/test_keywords.robot
+++ b/src/plone/app/robotframework/tests/docs/test_keywords.robot
@@ -1,5 +1,7 @@
 *** Settings ***
 
+Force Tags  wip-not_in_docs
+
 Resource  plone/app/robotframework/selenium.robot
 
 Library  Remote  ${PLONE_URL}/RobotRemote


### PR DESCRIPTION
…ing docs.plone.org

(actually, papyrus/docs will ignore any tests that are tagged with wip-* so you can give the reason more specific.)