### PR TITLE
Zope 4 compatibility

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,8 +4,9 @@ Changelog
 0.9.15 (unreleased)
 -------------------
 
-- Nothing changed yet.
-
+- Replace import of ``zope.testing.testrunner`` with ``zope.testrunner``.
+  [thet]
+  
 
 0.9.14 (2015-10-11)
 -------------------

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ install_requires = [
     'zope.configuration',
     'zope.i18n',
     'zope.schema',
-    'zope.testing',
+    'zope.testrunner',
 ]
 
 test_requires = [

--- a/src/plone/app/robotframework/server.py
+++ b/src/plone/app/robotframework/server.py
@@ -272,7 +272,7 @@ class Zope2Server:
         if layer_dotted_name:
             self.set_zope_layer(layer_dotted_name)
 
-        from zope.testing.testrunner.runner import order_by_bases
+        from zope.testrunner.runner import order_by_bases
         layers = order_by_bases([self.zope_layer])
         for layer in layers:
             if hasattr(layer, 'testSetUp'):
@@ -287,7 +287,7 @@ class Zope2Server:
         if layer_dotted_name:
             self.set_zope_layer(layer_dotted_name)
 
-        from zope.testing.testrunner.runner import order_by_bases
+        from zope.testrunner.runner import order_by_bases
         layers = order_by_bases([self.zope_layer])
         layers.reverse()
         for layer in layers:
@@ -327,7 +327,7 @@ def setup_layer(layer, setup_layers=setup_layers):
 
 
 def tear_down(setup_layers=setup_layers):
-    from zope.testing.testrunner.runner import order_by_bases
+    from zope.testrunner.runner import order_by_bases
     # Tear down any layers not needed for these tests. The unneeded layers
     # might interfere.
     unneeded = [l for l in setup_layers]


### PR DESCRIPTION
Replace import of zope.testing.testrunner with zope.testrunner.
Newer zope.testing.testrunner is deprecated.
This one is for Zope 4 compatibility.