### PR TITLE
Removed bad format parameter on ObjectModifiedEvent

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,8 +14,10 @@ New:
 
 Fixes:
 
-- *add item here*
-
+- Removed bad format parameter on ObjectModifiedEvent: must be an Attributes instance.
+  See zope.lifecycleevent.ObjectModifiedEvent class.
+  Removed because we can't get the interface and the correct fieldname.
+  [sgeulette]
 
 0.9.15 (2016-02-26)
 -------------------

--- a/src/plone/app/robotframework/content.py
+++ b/src/plone/app/robotframework/content.py
@@ -205,7 +205,7 @@ class Content(RemoteLibrary):
 
             setattr(obj, field, value)
             obj.reindexObject()
-            notify(ObjectModifiedEvent(obj, dict(field=value)))
+            notify(ObjectModifiedEvent(obj))
 
     def uid_to_url(self, uid):
         """Return absolute path for an UID"""


### PR DESCRIPTION
The format of the second parameter on ObjectModifiedEvent can't be a dict. It must be an Attributes instance: ObjectModifiedEvent(obj, Attributes(ISample, "field")) (zope.lifecycleevent.__init__.py).
As we can't have the field interface or the full fieldname, we can't add an Attributes instance. 
I have removed the parameter... 