### PR TITLE
Do not use run_on_failure from Selenium2Library.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,16 @@ Breaking changes:
 
 New features:
 
+- Do not use ``run_on_failure`` from ``Selenium2Library``.  This
+  interferes with ``Wait until keyword succeeds``: an initial failure
+  is seen as total failure instead of checking the retries of this
+  keyword.  Added ``Plone Test Setup`` and ``Plone Test Teardown``
+  keywords.  In that last one, in case of a failure do what used to be
+  done by ``run_on_failure``.  This means a screen shot by default,
+  but you can override this on the command line with for example
+  ``ROBOT_SELENIUM_RUN_ON_FAILURE=Debug``, or ``Nothing`` to ignore
+  it.  See https://github.com/plone/Products.CMFPlone/pull/1652  [maurits]
+
 - Add ``Running tests with the Google Chrome browser`` section.
   [thet]
 

--- a/src/plone/app/robotframework/selenium.robot
+++ b/src/plone/app/robotframework/selenium.robot
@@ -1,8 +1,11 @@
 *** Settings ***
 
+# We set run_on_failure to Nothing because anything else interferes with
+# 'Wait until keyword succeeds', interpreting an initial failure as complete failure,
+# instead of waiting for a successful retry.
 Library  Selenium2Library  timeout=${SELENIUM_TIMEOUT}
 ...                        implicit_wait=${SELENIUM_IMPLICIT_WAIT}
-...                        run_on_failure=${SELENIUM_RUN_ON_FAILURE}
+...                        run_on_failure=Nothing
 
 Resource  variables.robot
 Resource  ${CMFPLONE_SELECTORS}
@@ -36,6 +39,15 @@ Wait until location is
     ${IMPLICIT_WAIT} =  Get Selenium implicit wait
     Wait until keyword succeeds  ${TIMEOUT}  ${IMPLICIT_WAIT}
     ...                          Location should be  ${expected_url}
+
+Plone Test Setup
+    Open SauceLabs test browser
+    Refresh JS/CSS resources
+
+Plone Test Teardown
+    Run Keyword If Test Failed  ${SELENIUM_RUN_ON_FAILURE}
+    Report test status
+    Close all browsers
 
 # ----------------------------------------------------------------------------
 # Elements


### PR DESCRIPTION
This interferes with Wait until keyword succeeds: an initial failure
is seen as total failure instead of checking the retries of this
keyword.

Added `Plone Test Setup` and `Plone Test Teardown` keywords.  In that
last one, in case of a failure do what used to be done by
run_on_failure.  This means a screen shot by default, but you can
override this on the command line with for example
ROBOT_SELENIUM_RUN_ON_FAILURE=Debug, or Nothing to ignore it.

See https://github.com/plone/Products.CMFPlone/pull/1652