### PR TITLE
Replaced deprecated `Fail Unless Equal` with `Should Be Equal` in test.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,7 +25,8 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Replaced deprecated ``Fail Unless Equal`` with ``Should Be Equal``
+  in test.  [maurits]
 
 
 0.9.16 (2016-06-07)

--- a/src/plone/app/robotframework/tests/test_content_library.robot
+++ b/src/plone/app/robotframework/tests/test_content_library.robot
@@ -49,7 +49,7 @@ Test path to uid resolving
     ${uid} =  Create content  type=Document  id=example-document
     ...  title=Example document
     ${result_uid} =  Path to UID  /plone/example-document
-    Fail unless equal  ${uid}  ${result_uid}
+    Should Be Equal  ${uid}  ${result_uid}
 
 Test fire transition
     Enable autologin as  Contributor  Reviewer


### PR DESCRIPTION
This fixes a warning in Travis (or locally): `[ WARN ] Keyword 'DeprecatedBuiltIn.Fail Unless Equal' is deprecated. Use 'BuiltIn.Should Be Equal' instead.`
See https://travis-ci.org/plone/plone.app.robotframework/jobs/142141481
