### PR TITLE
Use `get_installer` for checking if a product is installed.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,9 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Use ``get_installer`` for checking if a product is installed.
+  Fall back to getting the ``portal_quickinstaller`` tool.
+  [maurits]
 
 
 1.1.1 (2017-06-28)

--- a/src/plone/app/robotframework/quickinstaller.py
+++ b/src/plone/app/robotframework/quickinstaller.py
@@ -2,22 +2,30 @@
 from zope.component.hooks import getSite
 from Products.CMFCore.utils import getToolByName
 from plone.app.robotframework.remote import RemoteLibrary
+try:
+    from Products.CMFPlone.utils import get_installer
+except ImportError:
+    # BBB for Plone 5.0 and lower.
+    get_installer = None
 
 
 class QuickInstaller(RemoteLibrary):
 
     def product_is_activated(self, product_name):
         """Assert that given product_name is activated (installed) in
-        portal_quickinstaller.
+        the add-ons control panel.
         """
         portal = getSite()
-        portal_quickinstaller = getToolByName(portal, 'portal_quickinstaller')
+        if get_installer is None:
+            qi = getToolByName(portal, 'portal_quickinstaller')
+            installed = qi.isProductInstalled(product_name)
+        else:
+            qi = get_installer(portal)
+            installed = qi.is_product_installed(product_name)
         portal_setup = getToolByName(portal, 'portal_setup')
-
-        installed = portal_quickinstaller.isProductInstalled(product_name)
-        imported = portal_setup.getProfileImportDate('profile-%s:default' %
-                                                     product_name)
+        imported = portal_setup.getProfileImportDate(
+            'profile-{0}:default'.format(product_name))
         assert installed or imported,\
-            u"Product '%s' was not activated." % product_name
+            u"Product '{0}' was not activated.".format(product_name)
 
     product_is_installed = product_is_activated


### PR DESCRIPTION
That will work on Plone 5.1+.
Fall back to getting the `portal_quickinstaller` tool on earlier Plones.