### PR TITLE
Import activatePluginInterfaces from Products.PlonePAS.setuphandlers.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,8 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Import ``activatePluginInterfaces`` from ``Products.PlonePAS.setuphandlers``.
+  [maurits]
 
 
 1.1.2 (2018-01-30)

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ install_requires = [
     'Products.CMFCore',
     'Products.CMFPlone',
     'Products.MailHost',
-    'Products.PlonePAS',
+    'Products.PlonePAS >= 5.0.1',
     'Products.PluggableAuthService',
     'babel',
     'five.globalrequest',

--- a/src/plone/app/robotframework/autologin.py
+++ b/src/plone/app/robotframework/autologin.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from Products.PlonePAS.Extensions.Install import activatePluginInterfaces
+from Products.PlonePAS.setuphandlers import activatePluginInterfaces
 from Products.PluggableAuthService.plugins import DomainAuthHelper
 from plone.app.robotframework.remote import RemoteLibrary
 from plone.app.robotframework.utils import disableCSRFProtection


### PR DESCRIPTION
Requires PlonePAS 5.0.1 (by default included since Plone 5.3.8).