### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@ plone.app.robotframework
 .. image:: https://saucelabs.com/buildstatus/parobotframework
        :target: https://saucelabs.com/u/parobotframework
 
-.. image:: https://pypip.in/v/plone.app.robotframework/badge.png
+.. image:: https://img.shields.io/pypi/v/plone.app.robotframework.svg
         :target: https://crate.io/packages/plone.app.robotframework
 
 **plone.app.robotframework** provides `Robot Framework


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20plone-app-robotframework))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `plone-app-robotframework`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.