### PR TITLE
Create user with roles

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,10 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Create user with roles
+  with args:   Create user  siteadmin  Contributor  Reviewer  Site Administrator
+  with kwargs: Create user  siteadmin  roles=('Contributor','Reviewer','Site Administrator')
+  [ksuess]
 
 
 1.2.0 (2018-02-23)

--- a/src/plone/app/robotframework/tests/test_users_library.robot
+++ b/src/plone/app/robotframework/tests/test_users_library.robot
@@ -25,16 +25,16 @@ Test user creation with roles as args
     Create user  siteadmin  Contributor  Reviewer  Site Administrator
     Disable autologin
     Log in  siteadmin  siteadmin
+    Go to homepage
     
-    Page should contain  You are now logged in
     Page should contain  siteadmin
     Page should contain  Manage portlets
 
 Test user creation with roles as kwarg
     Enable autologin as  Manager
-    Create user  siteadmin2  roles=('Contributor','Reviewer','Site Administrator')
-    Log in  siteadmin2  siteadmin2
+    Create user  siteadmin  roles=('Contributor','Reviewer','Site Administrator')
+    Log in  siteadmin  siteadmin
+    Go to homepage
     
-    Page should contain  You are now logged in
-    Page should contain  siteadmin2
+    Page should contain  siteadmin
     Page should contain  Manage portlets

--- a/src/plone/app/robotframework/tests/test_users_library.robot
+++ b/src/plone/app/robotframework/tests/test_users_library.robot
@@ -15,7 +15,26 @@ Test user creation and login as created user
     Enable autologin as  Manager
     Create user  johndoe  password=secret  username=John Doe
     Disable autologin
-
     Log in  johndoe  secret
 
-    Element should contain  id=user-name  johndoe
+    Page should contain  You are now logged in
+    Page should contain  johndoe
+
+Test user creation with roles as args
+    Enable autologin as  Manager
+    Create user  siteadmin  Contributor  Reviewer  Site Administrator
+    Disable autologin
+    Log in  siteadmin  siteadmin
+    
+    Page should contain  You are now logged in
+    Page should contain  siteadmin
+    Page should contain  Manage portlets
+
+Test user creation with roles as kwarg
+    Enable autologin as  Manager
+    Create user  siteadmin2  roles=('Contributor','Reviewer','Site Administrator')
+    Log in  siteadmin2  siteadmin2
+    
+    Page should contain  You are now logged in
+    Page should contain  siteadmin2
+    Page should contain  Manage portlets

--- a/src/plone/app/robotframework/users.py
+++ b/src/plone/app/robotframework/users.py
@@ -52,7 +52,8 @@ class Users(RemoteLibrary):
 
         user_id = use_email_as_username and properties['email'] or username
         password = properties.pop('password', username)
-        roles = properties.pop('roles', ('Member', ))
+        roles.extend(eval(properties.pop('roles', '()')))
+        roles.append('Member')
 
         properties['username'] = user_id
         registration.addMember(


### PR DESCRIPTION
Issue https://github.com/plone/plone.app.robotframework/issues/77

1. `Create user  siteadmin  Contributor  Reviewer  Site Administrator`
2. `Create user  siteadmin2  roles=('Contributor','Reviewer','Site Administrator')`

None of the two creates a user as expected.

1. creates a user with roles ('Member',)
2. creates a user with roles ('Contributor','Reviewer','Site Administrator'), missing role 'Member'
