### PR TITLE
Default to picking a free port.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,9 @@ Changelog
 
 Breaking changes:
 
-- *add item here*
+- Default to the new plone.testing default of picking the ZServer port
+  dynamically.
+  [Rotonen]
 
 New features:
 

--- a/src/plone/app/robotframework/variables.py
+++ b/src/plone/app/robotframework/variables.py
@@ -1,23 +1,12 @@
+from plone.testing.z2 import ZSERVER_FIXTURE
 import os
 import pkg_resources
 
-try:
-    from plone.testing.z2 import DEFAULT_ZSERVER_PORT
-except ImportError:
-    # DEFAULT_ZSERVER_PORT is not defined until plone.testing == 4.0.8
-    DEFAULT_ZSERVER_PORT = 55001
-
-# plone.testing checks environment to allow overriding DEFAULT_ZSERVER_PORT
-ZSERVER_PORT = os.environ.get('ZSERVER_PORT', DEFAULT_ZSERVER_PORT)
-
-# Allow specifying HOST and PORT through environment variables for instance,
-# if tests should go through a proxy
-ZOPE_HOST = os.environ.get('ZOPE_HOST', 'localhost')
-ZOPE_PORT = os.environ.get('ZOPE_PORT', ZSERVER_PORT)
+ZOPE_HOST = ZSERVER_FIXTURE.host
+ZOPE_PORT = ZSERVER_FIXTURE.port
 
 CMFPLONE_VERSION = pkg_resources.get_distribution('Products.CMFPlone').version
 if CMFPLONE_VERSION.startswith('4.'):
     CMFPLONE_SELECTORS = 'selectors/cmfplone43.robot'
 elif CMFPLONE_VERSION.startswith('5.'):
     CMFPLONE_SELECTORS = 'selectors/cmfplone50.robot'
-


### PR DESCRIPTION
@Rotonen this is missing so that 5.0 jobs do work as well.