### PR TITLE
Print ZServer and XMRPC URLs on server startup (Plone 5).

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,8 @@ Breaking changes:
 
 New features:
 
-- *add item here*
+- Print the ZServer and XMLRPC URLs when starting up the server.
+  [jone]
 
 Bug fixes:
 

--- a/src/plone/app/robotframework/server.py
+++ b/src/plone/app/robotframework/server.py
@@ -62,6 +62,8 @@ def start(zope_layer_dotted_name):
     listener.register_function(zsl.zodb_setup, 'zodb_setup')
     listener.register_function(zsl.zodb_teardown, 'zodb_teardown')
 
+    print_urls(zsl.zope_layer, listener)
+
     try:
         listener.serve_forever()
     finally:
@@ -71,6 +73,25 @@ def start(zope_layer_dotted_name):
         zsl.stop_zope_server()
 
         print(READY("Zope robot server stopped"))
+
+
+def print_urls(zope_layer, xmlrpc_server):
+    """Prints the urls with the chosen ports.
+
+    When using a port 0, the operating system chooses an open port.
+    When doing that it is helpful that the URLs with the chosen ports are printed to stdout.
+    """
+
+    for layer in zope_layer.baseResolutionOrder:
+        # Walk up the testing layers and look for the first zserver in order to get the
+        # actual server name and server port.
+        zserver = getattr(layer, 'zserver', None)
+        if not zserver:
+            continue
+        print('ZSERVER: http://{}:{}'.format(zserver.server_name, zserver.server_port))
+        break
+
+    print('XMLRPC: http://{0}:{1}'.format(*xmlrpc_server.server_address))
 
 
 def start_reload(zope_layer_dotted_name, reload_paths=('src',),


### PR DESCRIPTION
When starting the robot server, the ports for the ZServer and for the XMLRPC-server can be configured to 0 in order to let the operating system choose a random open port.

When the ports are randomly chosen, it is helpful that the server prints out the chosen ports in form of URLs, so that a caller may read the URLs in order to connect to the servers.

Back ported to Plone 4: #105