### PR TITLE
Patch selenium.is_connectable for Python 3 for ConnectionResetError

### DIFF
--- a/news/2786.bugfix
+++ b/news/2786.bugfix
@@ -1,0 +1,3 @@
+Patch selenium.is_connectable for Python 3 to retry on ConnectionResetError.
+See `issue 2786 <https://github.com/plone/Products.CMFPlone/issues/2786>`_.
+[maurits]

--- a/src/plone/app/robotframework/__init__.py
+++ b/src/plone/app/robotframework/__init__.py
@@ -25,3 +25,6 @@ from plone.app.robotframework.server import RobotListener
 
 # Robot Plone fixture
 from plone.app.robotframework.testing import PLONE_ROBOT_TESTING
+
+# Load our patches.  Call it _patches to mark it as private.
+from plone.app.robotframework import patches as _patches

--- a/src/plone/app/robotframework/patches.py
+++ b/src/plone/app/robotframework/patches.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+# Patch selenium.is_connectable for Python 3.
+# See https://github.com/SeleniumHQ/selenium/pull/6480
+# and for Plone: https://github.com/plone/Products.CMFPlone/issues/2786
+from selenium.webdriver.common import utils
+
+try:
+    # Python 3
+    ConnectionResetError
+except NameError:
+    # Python 2
+    ConnectionResetError = None
+
+
+if ConnectionResetError is not None:
+    orig_is_connectable = utils.is_connectable
+
+    def patched_is_connectable(port, host="localhost"):
+        try:
+            return orig_is_connectable(port, host=host)
+        except ConnectionResetError:
+            # Try again once.
+            return orig_is_connectable(port, host=host)
+
+    utils.is_connectable = patched_is_connectable


### PR DESCRIPTION
This retries once when we get a ConnectionResetError (which is a `builtin` in Python 3 and does not exist yet on Python 2).
Fixes https://github.com/plone/Products.CMFPlone/issues/2786.