### PR TITLE
Default to a 4K x 4K browser window

### DIFF
--- a/docs/source/happy.rst
+++ b/docs/source/happy.rst
@@ -138,8 +138,8 @@ For example, a ``test_hello.robot`` :
     Force Tags  wip-not_in_docs
 
     Resource  plone/app/robotframework/selenium.robot
-    Test Setup  Open test browser
-    Test Teardown  Close all browsers
+    Test Setup  Plone test setup
+    Test Teardown  Plone test teardown
 
   *** Test Cases ***
 
@@ -167,12 +167,13 @@ Here is a more complicated example with some user keywords in action:
 
     Force Tags  wip-not_in_docs
 
+    Resource  plone/app/robotframework/saucelabs.robot
     Resource  plone/app/robotframework/selenium.robot
 
     Library  Remote  ${PLONE_URL}/RobotRemote
 
-    Test Setup  Open test browser
-    Test Teardown  Close all browsers
+    Test Setup  Plone test setup
+    Test Teardown  Plone test teardown
 
     *** Variables ***
 
@@ -378,8 +379,8 @@ what to do next:
 
     Library  Remote  ${PLONE_URL}/RobotRemote
 
-    Test Setup  Open test browser
-    Test Teardown  Close all browsers
+    Test Setup  Plone test setup
+    Test Teardown  Plone test teardown
 
     *** Test Cases ***
 

--- a/news/110.bugfix
+++ b/news/110.bugfix
@@ -1,0 +1,2 @@
+- Stabilize tests by defaulting to a browser window size of 4K x 4K.
+  [Rotonen]

--- a/news/110.bugfix
+++ b/news/110.bugfix
@@ -3,3 +3,6 @@
 
 - Removed the legacy keyword ``Refresh JS/CSS resources``.
   [Rotonen]
+
+- Use the 'Plone test setup' and 'Plone test teardown' keywords in the Robot tests.
+  [Rotonen]

--- a/news/110.bugfix
+++ b/news/110.bugfix
@@ -1,2 +1,5 @@
 - Stabilize tests by defaulting to a browser window size of 4K x 4K.
   [Rotonen]
+
+- Removed the legacy keyword ``Refresh JS/CSS resources``.
+  [Rotonen]

--- a/src/plone/app/robotframework/selenium.robot
+++ b/src/plone/app/robotframework/selenium.robot
@@ -43,6 +43,7 @@ Wait until location is
 
 Plone Test Setup
     Open SauceLabs test browser
+    Run keyword and ignore error  Set window size  4096  4096
     Refresh JS/CSS resources
 
 Plone Test Teardown

--- a/src/plone/app/robotframework/selenium.robot
+++ b/src/plone/app/robotframework/selenium.robot
@@ -44,7 +44,6 @@ Wait until location is
 Plone Test Setup
     Open SauceLabs test browser
     Run keyword and ignore error  Set window size  4096  4096
-    Refresh JS/CSS resources
 
 Plone Test Teardown
     Run Keyword If Test Failed  ${SELENIUM_RUN_ON_FAILURE}

--- a/src/plone/app/robotframework/tests/docs/test_hello.robot
+++ b/src/plone/app/robotframework/tests/docs/test_hello.robot
@@ -2,10 +2,11 @@
 
 Force Tags  wip-not_in_docs
 
+Resource  plone/app/robotframework/saucelabs.robot
 Resource  plone/app/robotframework/selenium.robot
 
-Test Setup  Open test browser
-Test Teardown  Close all browsers
+Test Setup  Run keywords  Plone test setup
+Test Teardown  Run keywords  Plone test teardown
 
 *** Test Cases ***
 

--- a/src/plone/app/robotframework/tests/docs/test_keywords.robot
+++ b/src/plone/app/robotframework/tests/docs/test_keywords.robot
@@ -2,12 +2,13 @@
 
 Force Tags  wip-not_in_docs
 
+Resource  plone/app/robotframework/saucelabs.robot
 Resource  plone/app/robotframework/selenium.robot
 
 Library  Remote  ${PLONE_URL}/RobotRemote
 
-Test Setup  Open test browser
-Test Teardown  Close all browsers
+Test Setup  Run keywords  Plone test setup
+Test Teardown  Run keywords  Plone test teardown
 
 *** Variables ***
 

--- a/src/plone/app/robotframework/tests/test_autologin_library.robot
+++ b/src/plone/app/robotframework/tests/test_autologin_library.robot
@@ -1,13 +1,13 @@
 *** Settings ***
 
-Resource  plone/app/robotframework/selenium.robot
 Resource  plone/app/robotframework/keywords.robot
 Resource  plone/app/robotframework/saucelabs.robot
+Resource  plone/app/robotframework/selenium.robot
 
 Library  Remote  ${PLONE_URL}/RobotRemote
 
-Test Setup  Run keywords  Open SauceLabs test browser
-Test Teardown  Run keywords  Report test status  Close all browsers
+Test Setup  Run keywords  Plone test setup
+Test Teardown  Run keywords  Plone test teardown
 
 *** Test Cases ***
 

--- a/src/plone/app/robotframework/tests/test_content_library.robot
+++ b/src/plone/app/robotframework/tests/test_content_library.robot
@@ -1,12 +1,12 @@
 *** Settings ***
 
-Resource  plone/app/robotframework/selenium.robot
 Resource  plone/app/robotframework/saucelabs.robot
+Resource  plone/app/robotframework/selenium.robot
 
 Library  Remote  ${PLONE_URL}/RobotRemote
 
-Test Setup  Open SauceLabs test browser
-Test Teardown  Run keywords  Report test status  Close all browsers
+Test Setup  Run keywords  Plone test setup
+Test Teardown  Run keywords  Plone test teardown
 
 *** Test Cases ***
 

--- a/src/plone/app/robotframework/tests/test_i18n_library.robot
+++ b/src/plone/app/robotframework/tests/test_i18n_library.robot
@@ -1,13 +1,13 @@
 *** Settings ***
 
-Resource  plone/app/robotframework/selenium.robot
 Resource  plone/app/robotframework/keywords.robot
 Resource  plone/app/robotframework/saucelabs.robot
+Resource  plone/app/robotframework/selenium.robot
 
 Library  Remote  ${PLONE_URL}/RobotRemote
 
-Test Setup  Open SauceLabs test browser
-Test Teardown  Run keywords  Report test status  Close all browsers
+Test Setup  Run keywords  Plone test setup
+Test Teardown  Run keywords  Plone test teardown
 
 *** Test Cases ***
 

--- a/src/plone/app/robotframework/tests/test_robotfixture.robot
+++ b/src/plone/app/robotframework/tests/test_robotfixture.robot
@@ -1,13 +1,13 @@
 *** Settings ***
 
-Resource  plone/app/robotframework/selenium.robot
 Resource  plone/app/robotframework/keywords.robot
 Resource  plone/app/robotframework/saucelabs.robot
+Resource  plone/app/robotframework/selenium.robot
 
 Library  Remote  ${PLONE_URL}/RobotRemote
 
-Test Setup  Open SauceLabs test browser
-Test Teardown  Run keywords  Report test status  Close all browsers
+Test Setup  Run keywords  Plone test setup
+Test Teardown  Run keywords  Plone test teardown
 
 *** Test Cases ***
 

--- a/src/plone/app/robotframework/tests/test_speakjs_library.robot
+++ b/src/plone/app/robotframework/tests/test_speakjs_library.robot
@@ -1,15 +1,15 @@
 *** Settings ***
 
-Resource  plone/app/robotframework/selenium.robot
 Resource  plone/app/robotframework/keywords.robot
 Resource  plone/app/robotframework/saucelabs.robot
+Resource  plone/app/robotframework/selenium.robot
 Resource  plone/app/robotframework/annotate.robot
 Resource  plone/app/robotframework/speak.robot
 
 Library  Remote  ${PLONE_URL}/RobotRemote
 
-Test Setup  Open SauceLabs test browser
-Test Teardown  Run keywords  Report test status  Close all browsers
+Test Setup  Run keywords  Plone test setup
+Test Teardown  Run keywords  Plone test teardown
 
 *** Keywords ***
 

--- a/src/plone/app/robotframework/tests/test_users_library.robot
+++ b/src/plone/app/robotframework/tests/test_users_library.robot
@@ -1,13 +1,13 @@
 *** Settings ***
 
+Resource  plone/app/robotframework/keywords.robot
 Resource  plone/app/robotframework/selenium.robot
 Resource  plone/app/robotframework/saucelabs.robot
-Resource  plone/app/robotframework/keywords.robot
 
 Library  Remote  ${PLONE_URL}/RobotRemote
 
-Test Setup  Open SauceLabs test browser
-Test Teardown  Run keywords  Report test status  Close all browsers
+Test Setup  Run keywords  Plone test setup
+Test Teardown  Run keywords  Plone test teardown
 
 *** Test Cases ***
 
@@ -26,7 +26,7 @@ Test user creation with roles as args
     Disable autologin
     Log in  siteadmin  siteadmin
     Go to homepage
-    
+
     Page should contain  siteadmin
     Page should contain  Manage portlets
 
@@ -36,6 +36,6 @@ Test user creation with roles as kwarg
     Create user  siteadmin  roles=@{roles}
     Log in  siteadmin  siteadmin
     Go to homepage
-    
+
     Page should contain  siteadmin
     Page should contain  Manage portlets


### PR DESCRIPTION
The largest categories of Robot test flakiness we have are:
1) Things being unclickable by being outside the browser viewport
2) Interactive elements, like form buttons, collapsing into themselves in a way where they overlap in a mobile view

Both are caused by the default window size being a rather arcane 800 x 600. (Or in the case of Xvfb, also limited by the default desktop size and color depth of 640x480x8). In some cases, with Xvfb, the browser defaults, for unknown reasons, to a window size of 1024x768. None of these represent contemporary actual use very well.

The usability issues, especially the mobile ones, can be real usability issues and should thus be eventually tackled. I deem stable tests more valuable *at this point in time*. Currently these issues manifest mostly for people whom are **not** tackling them and they simply demotivate contributors.

Tackling those has also been a very annoying heisenbug for developers, as the browser window sizes on their local runs are different than on the CI as on desktop environments the default browser size is larger than in a naked X11 session. And someone with a smaller screen, for example on a smaller laptop, cannot even set their browser window size very large and is currently stuck with flakier Robot tests.

Thus we also need to use a headless browser without Xvfb for both the CI runs and local development. The support for this is already present in geckodriver, chromedriver, the version of Selenium we use, the version of Robot framework we use and thus also in our testing stack. Using a headless browser for local development is also a more pleasant experience as it does not spawn windows (some of which pop onto the foreground and gain focus). This allows the developer to do something else while waiting for the tests to run.

If there is just a single place from where the viewport size can be controlled, anyone interested in tackling these issues can do a local checkout of `plone.app.robotframework` and set the viewport size to whatever they're interested in working on.

I've figured out the path to get to that point and it starts here.

Attending to this one will happen in multiple parts:

1) Set the window size in `plone.app.robotframework` to a suitably unrealistic 4K x 4K
2) Remove window size setting from all Robot test layers and tests
3) Use the same shared test setup in all Robot tests
4) Use headless browsers on the CI instead of `xvfb-run` wrapped windowed browsers
5) Default to headless browsers for all Robot testing in Plone

For anyone interested in giving the headless browsers a spin locally:
`ROBOT_BROWSER=headlesschrome`
`ROBOT_BROWSER=headlessfirefox`