### PR TITLE
Reverted change in 1.2.1 for 'Log in' keyword which failed in Plone 4.3.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,9 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Reverted change in 1.2.1 for 'Log in' keyword which failed in Plone 4.3.
+  Fixes `issue 107 <https://github.com/plone/plone.app.robotframework/issues/107>`_.
+  [maurits]
 
 
 1.2.3 (2019-02-11)

--- a/src/plone/app/robotframework/keywords.robot
+++ b/src/plone/app/robotframework/keywords.robot
@@ -67,10 +67,10 @@ Log in
     Go to  ${PLONE_URL}/login_form
     Page should contain element  __ac_name
     Page should contain element  __ac_password
-    Page should contain element  xpath: //input[contains(text(), "Log in")]
+    Page should contain element  css=#login-form .formControls input[name=submit]
     Input text for sure  __ac_name  ${userid}
     Input text for sure  __ac_password  ${password}
-    Click Button  xpath: //input[contains(text(), "Log in")]
+    Click Button  css=#login-form .formControls input[name=submit]
 
 Log in as test user
 


### PR DESCRIPTION
Revert "Selector of login form matches text"

This reverts commit 9f80a05edceb71ae91e6da4dc69d353f4763863c.
Fixes https://github.com/plone/plone.app.robotframework/issues/107