### PR TITLE
Fixed error "Variable '${CMFPLONE_SELECTORS}' not found" on Plone 6.

### DIFF
--- a/news/680.bugfix
+++ b/news/680.bugfix
@@ -1,0 +1,2 @@
+Fixed error ``Variable '${CMFPLONE_SELECTORS}' not found`` on Plone 6.
+[maurits]

--- a/src/plone/app/robotframework/variables.py
+++ b/src/plone/app/robotframework/variables.py
@@ -15,5 +15,5 @@ ZOPE_PORT = WSGI_SERVER_FIXTURE.port
 CMFPLONE_VERSION = pkg_resources.get_distribution('Products.CMFPlone').version
 if CMFPLONE_VERSION.startswith('4.'):
     CMFPLONE_SELECTORS = 'selectors/cmfplone43.robot'
-elif CMFPLONE_VERSION.startswith('5.'):
+else:
     CMFPLONE_SELECTORS = 'selectors/cmfplone50.robot'


### PR DESCRIPTION
This is some example selector.
On Plone 6 the variable was not defined.
It makes all robot tests on Plone 6 broken, see https://github.com/plone/buildout.coredev/pull/680

```
[ ERROR ] Error in file
'/Users/maurits/community/plone-coredev/6.0/src/plone.app.robotframework/src/plone/app/robotframework/selenium.robot':
Replacing variables from setting 'Resource' failed: Variable '${CMFPLONE_SELECTORS}' not found.
```
