### PR TITLE
Removed backwards compatibility code for old quickinstaller.

### DIFF
--- a/news/1775.feature
+++ b/news/1775.feature
@@ -1,0 +1,4 @@
+Removed backwards compatibility code for old quickinstaller.
+Current plone.app.robotframework is only for Plone 5.2+, so this code was no longer used.
+See also `PLIP 1775 <https://github.com/plone/Products.CMFPlone/issues/1775>`_.
+[maurits]

--- a/src/plone/app/robotframework/quickinstaller.py
+++ b/src/plone/app/robotframework/quickinstaller.py
@@ -2,11 +2,7 @@
 from zope.component.hooks import getSite
 from Products.CMFCore.utils import getToolByName
 from plone.app.robotframework.remote import RemoteLibrary
-try:
-    from Products.CMFPlone.utils import get_installer
-except ImportError:
-    # BBB for Plone 5.0 and lower.
-    get_installer = None
+from Products.CMFPlone.utils import get_installer
 
 
 class QuickInstaller(RemoteLibrary):
@@ -16,12 +12,8 @@ class QuickInstaller(RemoteLibrary):
         the add-ons control panel.
         """
         portal = getSite()
-        if get_installer is None:
-            qi = getToolByName(portal, 'portal_quickinstaller')
-            installed = qi.isProductInstalled(product_name)
-        else:
-            qi = get_installer(portal)
-            installed = qi.is_product_installed(product_name)
+        qi = get_installer(portal)
+        installed = qi.is_product_installed(product_name)
         portal_setup = getToolByName(portal, 'portal_setup')
         imported = portal_setup.getProfileImportDate(
             'profile-{0}:default'.format(product_name))


### PR DESCRIPTION
Current plone.app.robotframework is only for Plone 5.2+, so this code was no longer used.
See also PLIP 1775: https://github.com/plone/Products.CMFPlone/issues/1775.

Can be tested and merged on its own.