### PR TITLE
Add support for robotframework-seleniumtestability

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,7 @@ install_requires = [
     "plone.uuid",
     "robotframework",
     "robotframework-selenium2library",
+    "robotframework-seleniumtestability",
     "robotsuite",  # not a direct dependency, but required for convenience
     "selenium",
     "setuptools",

--- a/src/plone/app/robotframework/selenium.robot
+++ b/src/plone/app/robotframework/selenium.robot
@@ -6,6 +6,7 @@
 Library  Selenium2Library  timeout=${SELENIUM_TIMEOUT}
 ...                        implicit_wait=${SELENIUM_IMPLICIT_WAIT}
 ...                        run_on_failure=${SELENIUM2LIBRARY_RUN_ON_FAILURE}
+...                        plugins=${SELENIUM2LIBRARY_PLUGINS}
 
 Resource  variables.robot
 Resource  ${CMFPLONE_SELECTORS}
@@ -16,6 +17,7 @@ ${SELENIUM_IMPLICIT_WAIT}  0.5
 ${SELENIUM_TIMEOUT}  7
 ${SELENIUM_RUN_ON_FAILURE}  Capture Page Screenshot
 ${SELENIUM2LIBRARY_RUN_ON_FAILURE}  No operation
+${SELENIUM2LIBRARY_PLUGINS}  ${None}
 
 ${BROWSER}  Firefox
 ${REMOTE_URL}


### PR DESCRIPTION
https://pypi.org/project/robotframework-seleniumtestability/ should add implicit wait for various browser actions to make testing more robust and faster (less sleep keywords required).

This implementation would make testability optional and active with
```
*** Variables ****************************************************************

${SELENIUM2LIBRARY_PLUGINS}  SeleniumTestability;True;7 Seconds;True
```
BUT. I HAVE NOT YET CONFIRMED TESTABILITY TO REALLY WORK. Instead I see related JavaScript errors in geckodriver.log. /cc @fredvd 

Requires additional versions for buildout.coredev
```
robotframework-seleniumtestability = 2.0.0
furl = 2.1.3
orderedmultidict = 1.0.1
```