### PR TITLE
Tests: sleep in 'Wait For Element' and 'Wait For Then Click Element'.

### DIFF
--- a/news/3582.bugfix
+++ b/news/3582.bugfix
@@ -1,0 +1,4 @@
+Tests: sleep in 'Wait For Element' and 'Wait For Then Click Element'.
+After this sleep, check that the element in question is there only once.
+Hopefully this will stabilize the Plone core robot tests.
+[maurits]

--- a/src/plone/app/robotframework/selenium.robot
+++ b/src/plone/app/robotframework/selenium.robot
@@ -102,6 +102,9 @@ Wait For Element
     Wait Until Page Contains Element  ${element}
     Set Focus To Element  ${element}
     Wait Until Element Is Visible  ${element}
+    Sleep  0.1
+    ${count} =  Get Element Count  ${element}
+    Should Be Equal as Numbers  ${count}  1
 
 Wait For Then Click Element
     [Documentation]  Can contain css=, jquery=, or any other element selector.
@@ -115,6 +118,9 @@ Wait For Then Click Invisible Element
     [Arguments]  ${element}
     Wait Until Page Contains Element  ${element}
     Set Focus To Element  ${element}
+    Sleep  0.1
+    ${count} =  Get Element Count  ${element}
+    Should Be Equal as Numbers  ${count}  1
     Click Element  ${element}
 
 # ----------------------------------------------------------------------------


### PR DESCRIPTION
After this sleep, check that the element in question is there only once.
Hopefully this will stabilize the Plone core robot tests.

See https://github.com/plone/Products.CMFPlone/issues/3582