### PR TITLE
Support playwright based robot tests via robotframework-browser extension

### DIFF
--- a/news/3813.feature
+++ b/news/3813.feature
@@ -1,0 +1,2 @@
+Add support for `playwright`-based tests via `robotframework-browser`.
+[datakurre]

--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,7 @@ install_requires = [
     "robotframework",
     "robotframework-selenium2library",
     "robotframework-seleniumtestability",
+    "robotframework-browser",
     "robotsuite",  # not a direct dependency, but required for convenience
     "selenium",
     "setuptools",

--- a/src/plone/app/robotframework/browser.robot
+++ b/src/plone/app/robotframework/browser.robot
@@ -7,7 +7,8 @@
 #
 # $ bin/rfbrowser init
 #
-# Creates video and trace with ROBOT_DEBUG=true
+# Pauses execution on error with ROBOT_DEBUG=true
+# Creates video and trace with ROBOT_TRACE=true
 # 
 # Traces can be viewed with
 #
@@ -27,7 +28,8 @@ ${BROWSER_RUN_ON_FAILURE}  Take Screenshot
 
 ${BROWSER}  chromium
 
-${ÐEBUG}
+${TRACE}
+${DEBUG}
 ${TRACING}  ${OUTPUT_DIR}/tracing
 
 *** Keywords ***
@@ -41,6 +43,10 @@ ${TRACING}  ${OUTPUT_DIR}/tracing
 Open Test Browser
     ${record_video}  Create dictionary   dir  ${OUTPUT_DIR}/video
     Run Keyword If  "${DEBUG}".lower() == "true"
+    ...    Open browser
+    ...        url=${START_URL}
+    ...        browser=${BROWSER}
+    ...    ELSE IF  "${TRACE}".lower() == "true"
     ...    New persistent context
     ...        url=${START_URL}
     ...        browser=${BROWSER}
@@ -56,7 +62,7 @@ Plone Test Setup
 
 Plone Test Teardown
     Run Keyword If Test Failed  ${BROWSER_RUN_ON_FAILURE}
-    Run Keyword If  "${DEBUG}".lower() == "true"  Sleep  1s
+    Run Keyword If  "${TRACE}".lower() == "true"  Sleep  1s
     Close browser
 
 Capture page screenshot

--- a/src/plone/app/robotframework/browser.robot
+++ b/src/plone/app/robotframework/browser.robot
@@ -1,0 +1,57 @@
+*** Settings ***
+
+# This browser.robot setups Robot tests with Playwright via robotframework-browser.
+# This browser.robot cannot be used with selenium.robot, saucelabs.robot or keywords.robot.
+
+# https://marketsquare.github.io/robotframework-browser/Browser.html#Importing
+
+Library  Browser  run_on_failure=${BROWSER_RUN_ON_FAILURE}
+
+Resource  variables.robot
+Resource  ${CMFPLONE_SELECTORS}
+
+*** Variables ***
+
+${BROWSER_RUN_ON_FAILURE}  Take Screenshot
+
+${BROWSER}  chromium
+
+${ÐEBUG}
+${TRACING}  ${OUTPUT_DIR}/tracing
+
+*** Keywords ***
+
+# ----------------------------------------------------------------------------
+# Browser
+# ----------------------------------------------------------------------------
+
+# https://marketsquare.github.io/robotframework-browser/Browser.html#New%20Persistent%20Context
+
+Open Test Browser
+    ${record_video}  Create dictionary   dir  ${OUTPUT_DIR}/video
+    Run Keyword If  "${DEBUG}".lower() == "true"
+    ...    New persistent context
+    ...        url=${START_URL}
+    ...        browser=${BROWSER}
+    ...        tracing=${TRACING}
+    ...        recordVideo=${record_video}
+    ...    ELSE
+    ...    New persistent context
+    ...        url=${START_URL}
+    ...        browser=${BROWSER}
+
+Plone Test Setup
+    Open Test Browser
+
+Plone Test Teardown
+    Run Keyword If Test Failed  ${BROWSER_RUN_ON_FAILURE}
+    Run Keyword If  "${DEBUG}".lower() == "true"  Sleep  1s
+    Close browser
+
+Capture page screenshot
+    Take screenshot
+
+Capture page screenshot and log source
+    Take screenshot
+    ${source}=  Get page source
+    Log source  ${source}

--- a/src/plone/app/robotframework/browser.robot
+++ b/src/plone/app/robotframework/browser.robot
@@ -7,15 +7,16 @@
 #
 # $ bin/rfbrowser init
 #
-# Pauses execution on error with ROBOT_DEBUG=true
 # Creates video and trace with ROBOT_TRACE=true
-# 
+# Pauses execution on error with ROBOT_DEBUG=true
+# Run browser as headless with ROBOT_HEADLESS=true
+# Is backwards compatible with ROBOT_BROWESR=headless[browsername]
+#
 # Traces can be viewed with
 #
 # $ bin/rfbrowser -F parts/test/*/*/tracing show-trace
 #
-
-# https://marketsquare.github.io/robotframework-browser/Browser.html#Importing
+# Keywords: https://marketsquare.github.io/robotframework-browser/Browser.html
 
 Library  Browser  run_on_failure=${BROWSER_RUN_ON_FAILURE}
 
@@ -26,10 +27,11 @@ Resource  ${CMFPLONE_SELECTORS}
 
 ${BROWSER_RUN_ON_FAILURE}  Take Screenshot
 
-${BROWSER}  chromium
+${BROWSER}  headlesschromium
 
-${TRACE}
-${DEBUG}
+${DEBUG}  false
+${HEADLESS}  false
+${TRACE}  false
 ${TRACING}  ${OUTPUT_DIR}/tracing
 
 *** Keywords ***
@@ -40,29 +42,47 @@ ${TRACING}  ${OUTPUT_DIR}/tracing
 
 # https://marketsquare.github.io/robotframework-browser/Browser.html#New%20Persistent%20Context
 
+Configure Test Browser
+    ${DEBUG}=     Set Variable If     "${DEBUG}".lower() in ["1", "on", "true", "yes"]  ${TRUE}  ${FALSE}
+    ${TRACE}=     Set Variable If     "${TRACE}".lower() in ["1", "on", "true", "yes"]  ${TRUE}  ${FALSE}
+    ${HEADLESS}=  Set Variable If     "${HEADLESS}".lower() in ["1", "on", "true", "yes"]  ${TRUE}  ${FALSE}
+    ${HEADLESS}=  Set Variable if     "${BROWSER}".startswith("headless")  ${TRUE}  ${HEADLESS}
+    ${HEADLESS}=  Set Variable If     ${TRACE}  ${FALSE}  ${HEADLESS}
+    ${HEADLESS}=  Set Variable If     ${DEBUG}  ${FALSE}  ${HEADLESS}
+    ${BROWSER}=   Set Variable if     "${BROWSER}".startswith("headless")  ${BROWSER[len("headless"):]}  ${BROWSER}
+    ${VIDEO}=     Create dictionary   dir  ${OUTPUT_DIR}/video
+
+    Set Suite Variable  ${BROWSER}    ${BROWSER}
+    Set Suite Variable  ${DEBUG}      ${DEBUG}
+    Set Suite Variable  ${HEADLESS}   ${HEADLESS}
+    Set Suite Variable  ${TRACE}      ${TRACE}
+    Set Suite Variable  ${VIDEO}      ${VIDEO}
+
 Open Test Browser
-    ${record_video}  Create dictionary   dir  ${OUTPUT_DIR}/video
-    Run Keyword If  "${DEBUG}".lower() == "true"
+    Configure Test Browser
+    Run Keyword If  ${DEBUG}
     ...    Open browser
     ...        url=${START_URL}
     ...        browser=${BROWSER}
-    ...    ELSE IF  "${TRACE}".lower() == "true"
+    ...    ELSE IF  ${TRACE}
     ...    New persistent context
     ...        url=${START_URL}
     ...        browser=${BROWSER}
     ...        tracing=${TRACING}
-    ...        recordVideo=${record_video}
+    ...        headless=${HEADLESS}
+    ...        recordVideo=${VIDEO}
     ...    ELSE
     ...    New persistent context
     ...        url=${START_URL}
     ...        browser=${BROWSER}
+    ...        headless=${HEADLESS}
 
 Plone Test Setup
     Open Test Browser
 
 Plone Test Teardown
     Run Keyword If Test Failed  ${BROWSER_RUN_ON_FAILURE}
-    Run Keyword If  "${TRACE}".lower() == "true"  Sleep  1s
+    Run Keyword If  ${TRACE}  Sleep  1s
     Close browser
 
 Capture page screenshot
@@ -71,4 +91,4 @@ Capture page screenshot
 Capture page screenshot and log source
     Take screenshot
     ${source}=  Get page source
-    Log source  ${source}
+    Log  ${source}

--- a/src/plone/app/robotframework/browser.robot
+++ b/src/plone/app/robotframework/browser.robot
@@ -3,6 +3,17 @@
 # This browser.robot setups Robot tests with Playwright via robotframework-browser.
 # This browser.robot cannot be used with selenium.robot, saucelabs.robot or keywords.robot.
 
+# Requires initialization::
+#
+# $ bin/rfbrowser init
+#
+# Creates video and trace with ROBOT_DEBUG=true
+# 
+# Traces can be viewed with
+#
+# $ bin/rfbrowser -F parts/test/*/*/tracing show-trace
+#
+
 # https://marketsquare.github.io/robotframework-browser/Browser.html#Importing
 
 Library  Browser  run_on_failure=${BROWSER_RUN_ON_FAILURE}

--- a/src/plone/app/robotframework/browser.robot
+++ b/src/plone/app/robotframework/browser.robot
@@ -50,6 +50,7 @@ Configure Test Browser
     ${HEADLESS}=  Set Variable If     ${TRACE}  ${FALSE}  ${HEADLESS}
     ${HEADLESS}=  Set Variable If     ${DEBUG}  ${FALSE}  ${HEADLESS}
     ${BROWSER}=   Set Variable if     "${BROWSER}".startswith("headless")  ${BROWSER[len("headless"):]}  ${BROWSER}
+    ${BROWSER}=   Set Variable if     "${BROWSER}" == "chrome"  chromium  ${BROWSER}
     ${VIDEO}=     Create dictionary   dir  ${OUTPUT_DIR}/video
 
     Set Suite Variable  ${BROWSER}    ${BROWSER}

--- a/src/plone/app/robotframework/tests/test_browser_library.robot
+++ b/src/plone/app/robotframework/tests/test_browser_library.robot
@@ -1,0 +1,7 @@
+*** Settings ***
+Library   Browser
+
+*** Test Cases ***
+Example Test
+    New Page    https://playwright.dev
+    Get Text    h1    ==    🎭 Playwrighe

--- a/src/plone/app/robotframework/tests/test_browser_library.robot
+++ b/src/plone/app/robotframework/tests/test_browser_library.robot
@@ -1,7 +1,19 @@
 *** Settings ***
-Library   Browser
+
+Resource  plone/app/robotframework/browser.robot
+
+Library  Remote  ${PLONE_URL}/RobotRemote
+
+Test Setup  Run keywords  Plone test setup
+Test Teardown  Run keywords  Plone test teardown
 
 *** Test Cases ***
-Example Test
-    New Page    https://playwright.dev
-    Get Text    h1    ==    🎭 Playwrighe
+
+Test create content
+    Enable autologin as  Contributor
+    Create content  type=Document  id=example-document  title=Example document
+    Go to  ${PLONE_URL}/example-document
+    Get text  h1  Should be  Example document
+   
+# https://marketsquare.github.io/robotframework-browser/Browser.html#Assertions
+    

--- a/src/plone/app/robotframework/tests/test_robot.py
+++ b/src/plone/app/robotframework/tests/test_robot.py
@@ -23,6 +23,10 @@ def test_suite():
     suite.addTests(
         [
             layered(
+                robotsuite.RobotTestSuite("test_browser_library.robot"),
+                layer=SIMPLE_PUBLICATION_ROBOT_TESTING,
+            ),
+            layered(
                 robotsuite.RobotTestSuite("test_autologin_library.robot"),
                 layer=SIMPLE_PUBLICATION_ROBOT_TESTING,
             ),


### PR DESCRIPTION
__Big disclaimer:__ I'm (@gforcada) merely the one that created the PR, the code and credits for this feature, as commits show, goes to @datakurre ✨ 💯 

⚠️ It needs the version pins defined on [this buildout.coredev branch](https://github.com/plone/buildout.coredev/tree/datakurre-rfbrowser).

Part of https://github.com/plone/Products.CMFPlone/issues/3813