### PR TITLE
Avoid duplicate installation of plone.app.contenttypes profile

### DIFF
--- a/news/154.bugfix
+++ b/news/154.bugfix
@@ -1,0 +1,1 @@
+Fix duplicate installation of plone.app.contenttypes:default profile. @davisagli

--- a/src/plone/app/robotframework/testing.py
+++ b/src/plone/app/robotframework/testing.py
@@ -45,7 +45,6 @@ class SimplePublicationLayer(Layer):
 
     def setUp(self):
         with ploneSite() as portal:
-            applyProfile(portal, "plone.app.contenttypes:default")
             portal.portal_workflow.setDefaultChain("simple_publication_workflow")
 
     def tearDown(self):
@@ -56,15 +55,8 @@ class SimplePublicationLayer(Layer):
 SIMPLE_PUBLICATION_FIXTURE = SimplePublicationLayer()
 
 
-class SimplePublicationWithTypesLayer(Layer):
-    defaultBases = (SIMPLE_PUBLICATION_FIXTURE,)
-
-    def setUp(self):
-        with ploneSite() as portal:
-            applyProfile(portal, "plone.app.contenttypes:default")
-
-
-SIMPLE_PUBLICATION_WITH_TYPES_FIXTURE = SimplePublicationLayer()
+SimplePublicationWithTypesLayer = SimplePublicationLayer
+SIMPLE_PUBLICATION_WITH_TYPES_FIXTURE = SIMPLE_PUBLICATION_FIXTURE
 
 
 class MockMailHostLayer(Layer):


### PR DESCRIPTION
In Plone 6, the plone.app.contenttypes profile is already installed by the PLONE_FIXTURE. So it's not necessary for SimplePublicationLayer to install it again.

This avoids printing a warning that plone.app.event is already installed, and avoids some unnecessary work.