### PR TITLE
Fix printing the server URL in non-reload mode

### DIFF
--- a/news/155.bugfix
+++ b/news/155.bugfix
@@ -1,0 +1,1 @@
+Fix printing the server URL when robot-server is run without reloading enabled. @davisagli

--- a/src/plone/app/robotframework/server.py
+++ b/src/plone/app/robotframework/server.py
@@ -86,7 +86,9 @@ def print_urls(zope_layer, xmlrpc_server):
         # actual server name and server port.
         zserver = getattr(layer, "zserver", None)
         if zserver:
-            print(f"Zope is running at: http://{zserver.server_name}:{zserver.server_port}/")
+            print(
+                f"Zope is running at: http://{zserver.server_name}:{zserver.server_port}/"
+            )
             break
         server = getattr(layer, "server", None)
         if server:

--- a/src/plone/app/robotframework/server.py
+++ b/src/plone/app/robotframework/server.py
@@ -79,16 +79,19 @@ def print_urls(zope_layer, xmlrpc_server):
     When doing that it is helpful that the URLs with the chosen ports are printed to stdout.
     """
 
+    print("Robot XMLRPC: http://{}:{}".format(*xmlrpc_server.server_address))
+
     for layer in zope_layer.baseResolutionOrder:
         # Walk up the testing layers and look for the first zserver in order to get the
         # actual server name and server port.
         zserver = getattr(layer, "zserver", None)
-        if not zserver:
-            continue
-        print(f"ZSERVER: http://{zserver.server_name}:{zserver.server_port}")
-        break
-
-    print("XMLRPC: http://{}:{}".format(*xmlrpc_server.server_address))
+        if zserver:
+            print(f"Zope is running at: http://{zserver.server_name}:{zserver.server_port}/")
+            break
+        server = getattr(layer, "server", None)
+        if server:
+            print(f"Zope is running at: {server.application_url}")
+            break
 
 
 def start_reload(


### PR DESCRIPTION
When robot-server starts without reloading enabled (including when it runs in the plone/server-acceptance container), it tries to print the URL where the server is accepting HTTP requests. But, this only worked for ZServer-based layers and not WSGI server-based layers.