### PR TITLE
Makes ``Wait For Then Click Element`` keyword more robust

### DIFF
--- a/news/157.bugfix
+++ b/news/157.bugfix
@@ -1,0 +1,1 @@
+Makes ``Wait For Then Click Element`` keyword more robust. @wesleybl

--- a/src/plone/app/robotframework/selenium.robot
+++ b/src/plone/app/robotframework/selenium.robot
@@ -101,8 +101,9 @@ Wait For Element
     ...              Element must match exactly one time.
     [Arguments]  ${element}
     Wait Until Page Contains Element  ${element}
-    Set Focus To Element  ${element}
     Wait Until Element Is Visible  ${element}
+    Wait Until Element Is Enabled  ${element}
+    Set Focus To Element  ${element}
     Sleep  0.1
     ${count} =  Get Element Count  ${element}
     Should Be Equal as Numbers  ${count}  1
@@ -112,8 +113,9 @@ Wait For Elements
     ...              Element may match more than once.
     [Arguments]  ${element}
     Wait Until Page Contains Element  ${element}
-    Set Focus To Element  ${element}
     Wait Until Element Is Visible  ${element}
+    Wait Until Element Is Enabled  ${element}
+    Set Focus To Element  ${element}
 
 Wait For Then Click Element
     [Documentation]  Can contain css=, jquery=, or any other element selector.


### PR DESCRIPTION
Wait for the element to become visible and enabled before trying to focus on it. 

This fixes: https://jenkins.plone.org/job/pull-request-6.0-3.11/1192/robot/report/robot_log.html#s1-s21-t3